### PR TITLE
Fix jumping to symlinks that are not in the database when using nushell

### DIFF
--- a/templates/nushell.txt
+++ b/templates/nushell.txt
@@ -60,7 +60,7 @@ def --env --wrapped __zoxide_z [...rest: string] {
   let path = match $rest {
     [] => {'~'},
     [ '-' ] => {'-'},
-    [ $arg ] if ($arg | path type) == 'dir' => {$arg}
+    [ $arg ] if ($arg | path expand | path type) == 'dir' => {$arg}
     _ => {
       zoxide query --exclude $env.PWD -- ...$rest | str trim -r -c "\n"
     }


### PR DESCRIPTION
Fixes #1024

Expand path before checking for its type. This solves the issue of ignoring symlinks. Expanding the path is necessary to ensure that it resolves to a directory, as it's possible that the symlink could be a normal file.

Because the path expansion is only done in the guard, the behavior of `_ZO_RESOLVE_SYMLINKS` remains as intended.

The linked issue shows the problem in detail, but I will duplicate the shell log here:
```
> zoxide --version
zoxide 0.9.7

> nu --version
0.103.0


> mkdir foo
> touch foo/bar
> ln -s foo foosym
> cd foo
> ls
╭───┬──────┬──────┬──────┬──────────────╮
│ # │ name │ type │ size │   modified   │
├───┼──────┼──────┼──────┼──────────────┤
│ 0 │ bar  │ file │  0 B │ a minute ago │
╰───┴──────┴──────┴──────┴──────────────╯

> cd
> cd foosym
zoxide: no match found

> zoxide add foosym
> cd foosym
> ls
╭───┬──────┬──────┬──────┬────────────────╮
│ # │ name │ type │ size │    modified    │
├───┼──────┼──────┼──────┼────────────────┤
│ 0 │ bar  │ file │  0 B │ 19 seconds ago │
╰───┴──────┴──────┴──────┴────────────────╯
```